### PR TITLE
#163671168 Add GET /offices/<office-id> Endpoint API

### DIFF
--- a/src/controllers/office.js
+++ b/src/controllers/office.js
@@ -38,6 +38,32 @@ class Office {
       data: [office],
     });
   }
+
+  static getOffice(req, res) {
+    let { id } = req.params;
+    id = Number(id);
+
+    if (Number.isNaN(id)) {
+      return res.status(422).json({
+        status: 422,
+        error: 'Office ID is invalid',
+      });
+    }
+
+    const office = officeDb.findOne(id);
+
+    if (!office) {
+      return res.status(404).json({
+        status: 404,
+        error: 'Office not found',
+      });
+    }
+
+    return res.status(200).json({
+      status: 200,
+      data: [office],
+    });
+  }
 }
 
 export default Office;

--- a/src/routes/office.js
+++ b/src/routes/office.js
@@ -4,5 +4,6 @@ import OfficeControl from '../controllers/office';
 const router = express.Router();
 
 router.post('/', OfficeControl.post);
+router.get('/:id', OfficeControl.getOffice);
 
 export default router;

--- a/test/routes.spec.js
+++ b/test/routes.spec.js
@@ -779,3 +779,120 @@ describe('POST /api/v1/offices', () => {
     });
   });
 });
+
+/* ****** Feature: Get an office ******* */
+describe('GET /api/v1/offices/<office-id>', () => {
+  describe('On successful request/response cycle', () => {
+    it('should return status and data properties', (done) => {
+      chai.request(server)
+        .get('/api/v1/offices/1')
+        .end((err, res) => {
+          expect(res.body).to.have.all.keys('status', 'data');
+          return done();
+        });
+    });
+
+    it('should return status property of number type', (done) => {
+      chai.request(server)
+        .get('/api/v1/offices/1')
+        .end((err, res) => {
+          expect(res.body).to.have.ownProperty('status').that.is.a('number');
+          return done();
+        });
+    });
+
+    it('should return data property of array type', (done) => {
+      chai.request(server)
+        .get('/api/v1/offices/1')
+        .end((err, res) => {
+          expect(res.body).to.have.ownProperty('data').that.is.an('array');
+          return done();
+        });
+    });
+
+    it('should return correct status code', (done) => {
+      chai.request(server)
+        .get('/api/v1/offices/1')
+        .end((err, res) => {
+          expect(res).to.have.status(200);
+          return done();
+        });
+    });
+
+    it('should return data of single element', (done) => {
+      chai.request(server)
+        .get('/api/v1/offices/1')
+        .end((err, res) => {
+          expect(res.body.data).to.have.lengthOf(1);
+          return done();
+        });
+    });
+
+    describe('Element of data property', () => {
+      it('should return id property of number type', (done) => {
+        chai.request(server)
+          .get('/api/v1/offices/1')
+          .end((err, res) => {
+            expect(res.body.data[0]).to.have.ownProperty('id').that.is.a('number');
+            return done();
+          });
+      });
+
+      it('should return name property of string type', (done) => {
+        chai.request(server)
+          .get('/api/v1/offices/1')
+          .end((err, res) => {
+            expect(res.body.data[0]).to.have.ownProperty('type').that.is.a('string');
+            return done();
+          });
+      });
+
+      it('should return logoUrl property of string type', (done) => {
+        chai.request(server)
+          .get('/api/v1/offices/1')
+          .end((err, res) => {
+            expect(res.body.data[0]).to.have.ownProperty('name').that.is.a('string');
+            return done();
+          });
+      });
+    });
+  });
+
+  describe('On failed request/response cycle', () => {
+    it('should return status and error properties', (done) => {
+      chai.request(server)
+        .get('/api/v1/offices/0')
+        .end((err, res) => {
+          expect(res.body).to.have.all.keys('status', 'error');
+          return done();
+        });
+    });
+
+    it('should return status property of number type', (done) => {
+      chai.request(server)
+        .get('/api/v1/offices/null')
+        .end((err, res) => {
+          expect(res.body).to.have.ownProperty('status').that.is.a('number');
+          return done();
+        });
+    });
+
+    it('should return error property of string type', (done) => {
+      chai.request(server)
+        .get('/api/v1/offices/undefined')
+        .end((err, res) => {
+          expect(res.body).to.have.ownProperty('error').that.is.a('string');
+          return done();
+        });
+    });
+
+    it('should return correct status code', (done) => {
+      chai.request(server)
+        .get('/api/v1/offices/abc')
+        .end((err, res) => {
+          expect(res).to.have.status(422);
+          return done();
+        });
+    });
+  });
+});


### PR DESCRIPTION
#### What does this PR do?
Have Read operation work on offices endpoint
#### Description of Task to be completed?
Have ```GET /api/v1/offices/<office-id>``` to work
Response spec: ```{ "status": Integer, "data": [{ "id": Integer, "type": String, "name": String }] }```
#### How should this be manually tested?
Clone the repo, ```cd``` into it
- On terminal
Run ```npm test```
Then all tests should pass
- On Postman
Run ```npm start```
Launch Postman and send request
#### What are the relevant pivotal tracker stories?
#163671168