### PR TITLE
#163671207 Implement API for GET /offices Endpoints

### DIFF
--- a/src/controllers/office.js
+++ b/src/controllers/office.js
@@ -64,6 +64,22 @@ class Office {
       data: [office],
     });
   }
+
+  static getAllOffices(req, res) {
+    const officeList = officeDb.findAll();
+
+    if (!officeList) {
+      return res.status(404).json({
+        status: 404,
+        error: 'No office in the Database',
+      });
+    }
+
+    return res.status(200).json({
+      status: 200,
+      data: officeList,
+    });
+  }
 }
 
 export default Office;

--- a/src/index.js
+++ b/src/index.js
@@ -4,11 +4,11 @@ import officeRouter from './routes/office';
 
 const app = express();
 app.use(express.json());
-const port = process.env.PORT || 3000;
 
 app.use('/api/v1/parties', partyRouter);
 app.use('/api/v1/offices', officeRouter);
 
+const port = process.env.PORT || 3000;
 app.listen(port, () => {
   console.log(`Server is ready at port ${port}`);
 });

--- a/src/routes/office.js
+++ b/src/routes/office.js
@@ -5,5 +5,6 @@ const router = express.Router();
 
 router.post('/', OfficeControl.post);
 router.get('/:id', OfficeControl.getOffice);
+router.get('/', OfficeControl.getAllOffices);
 
 export default router;

--- a/test/routes.spec.js
+++ b/test/routes.spec.js
@@ -2,6 +2,7 @@ import chai from 'chai';
 import chaiHttp from 'chai-http';
 import server from '../src/index';
 import partyDb from '../src/models/party';
+import officeDb from '../src/models/office';
 
 const { expect } = chai;
 chai.use(chaiHttp);
@@ -891,6 +892,117 @@ describe('GET /api/v1/offices/<office-id>', () => {
         .get('/api/v1/offices/abc')
         .end((err, res) => {
           expect(res).to.have.status(422);
+          return done();
+        });
+    });
+  });
+});
+
+/* ****** Feature: Get all offices ******* */
+describe('GET /api/v1/offices', () => {
+  describe('On successful request/response cycle', () => {
+    before(function xyz() {
+      if (!officeDb.findAll().length) {
+        this.skip();
+      }
+    });
+
+    it('should return status and data properties', (done) => {
+      chai.request(server)
+        .get('/api/v1/offices')
+        .end((err, res) => {
+          expect(res.body).to.have.all.keys('status', 'data');
+          return done();
+        });
+    });
+
+    it('should return status property of number type', (done) => {
+      chai.request(server)
+        .get('/api/v1/offices')
+        .end((err, res) => {
+          expect(res.body).to.have.ownProperty('status').that.is.a('number');
+          return done();
+        });
+    });
+
+    it('should return data property of array type', (done) => {
+      chai.request(server)
+        .get('/api/v1/offices')
+        .end((err, res) => {
+          expect(res.body).to.have.ownProperty('data').that.is.an('array');
+          return done();
+        });
+    });
+
+    it('should return correct status code', (done) => {
+      chai.request(server)
+        .get('/api/v1/offices')
+        .end((err, res) => {
+          expect(res).to.have.status(200);
+          return done();
+        });
+    });
+
+    describe('Element of data property', () => {
+      it('should return id property of number type', (done) => {
+        chai.request(server)
+          .get('/api/v1/offices')
+          .end((err, res) => {
+            expect(res.body.data[0]).to.have.ownProperty('id').that.is.a('number');
+            return done();
+          });
+      });
+
+      it('should return name property of string type', (done) => {
+        chai.request(server)
+          .get('/api/v1/offices')
+          .end((err, res) => {
+            expect(res.body.data[0]).to.have.ownProperty('name').that.is.a('string');
+            return done();
+          });
+      });
+    });
+  });
+
+  describe('On failed request/response cycle', () => {
+    before(function xyz() {
+      if (officeDb.findAll().length) {
+        this.skip();
+      }
+    });
+
+    it('should return status and error properties', (done) => {
+      chai.request(server)
+        .get('/api/v1/offices/0')
+        .end((err, res) => {
+          expect(res.body).to.have.all.keys('status', 'error');
+          return done();
+        });
+    });
+
+    it('should return status property of number type', (done) => {
+      chai.request(server)
+        .get('/api/v1/offices')
+        .end((err, res) => {
+          expect(res.body).to.have.ownProperty('status').that.is.a('number');
+          return done();
+        });
+    });
+
+    it('should return error property of string type', (done) => {
+      chai.request(server)
+        .get('/api/v1/offices')
+        .end((err, res) => {
+          expect(res.body).to.have.ownProperty('error').that.is.a('string');
+          return done();
+        });
+    });
+
+    it('should return correct status code', (done) => {
+      chai.request(server)
+        .get('/api/v1/offices')
+        .end((err, res) => {
+          expect(res).to.have.status(404);
           return done();
         });
     });


### PR DESCRIPTION
#### What does this PR do?
Have Read operation work on offices endpoint
#### Description of Task to be completed?
Have ```GET /api/v1/offices``` to work
Response spec: ```{ "status": Integer, "data": [{ "id": Integer, "type": String, "name": String }] }```
#### How should this be manually tested?
Clone the repo, ```cd``` into it
- On terminal
Run ```npm test```
Then all tests should pass
- On Postman
Run ```npm start```
Launch Postman and send request
#### What are the relevant pivotal tracker stories?
#163671207